### PR TITLE
Manage redirection of SPA with a simpler server backend based on SWS

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,27 @@
-FROM nginx:1.23.0-alpine
+# syntax=docker/dockerfile:1.8.1
 
-COPY ./dist /usr/share/nginx/html
+FROM joseluisq/static-web-server:2.32.0
+
+COPY <<EOF /config.toml
+  [general]
+
+  host = "::"
+  port = 80
+  root = "/mergeable"
+  log-level = "info"
+
+  page-fallback = "/mergeable/index.html"
+  cache-control-headers = true
+  compression = true
+  security-headers = true
+  directory-listing = false
+  redirect-trailing-slash = true
+  compression-static = true
+  ignore-hidden-files = true
+EOF
+
+COPY ./dist /mergeable
+
+ENV SERVER_CONFIG_FILE=config.toml
 
 EXPOSE 80


### PR DESCRIPTION
This new implementation solves the case where the backend returns 404 if the page loaded is `/settings` or `/stars`.
Additionally, this brings a very light server, with less CVE and build on top of distroless image.

Closes https://github.com/pvcnt/mergeable/issues/51