### PR TITLE
build: remove import of blueprint-icons.css

### DIFF
--- a/apps/webapp/src/main.scss
+++ b/apps/webapp/src/main.scss
@@ -1,3 +1,6 @@
+@import "normalize.css/normalize.css";
+@import "@blueprintjs/core/lib/css/blueprint.css";
+@import "@blueprintjs/select/lib/css/blueprint-select.css";
 @import "@blueprintjs/core/lib/scss/variables";
 
 *:focus {

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -11,11 +11,6 @@ import ErrorPage from "./error-page.tsx";
 import Dashboard from "./routes/dashboard.tsx";
 import Settings from "./routes/settings.tsx";
 import Stars from "./routes/stars.tsx";
-
-import "normalize.css/normalize.css";
-import "@blueprintjs/icons/lib/css/blueprint-icons.css";
-import "@blueprintjs/core/lib/css/blueprint.css";
-import "@blueprintjs/select/lib/css/blueprint-select.css";
 import "./main.scss";
 
 const router = createBrowserRouter([


### PR DESCRIPTION
Cf. https://github.com/palantir/blueprint/issues/6401 This import is not useful if not using the icon fonts, while adding significant size to the bundle.