### PR TITLE
fix: splitting queries incorrectly removed quotes

### DIFF
--- a/packages/github/src/search.ts
+++ b/packages/github/src/search.ts
@@ -20,6 +20,7 @@ export function splitQueries(search: string): string[] {
       query = "";
     } else if (c === '"') {
       quoted = !quoted;
+      query += c;
     } else {
       query += c;
     }

--- a/packages/github/tests/search.test.ts
+++ b/packages/github/tests/search.test.ts
@@ -128,7 +128,8 @@ test("split a search string into queries", () => {
   expect(splitQueries("a")).toEqual(["a"]);
   expect(splitQueries("a;b")).toEqual(["a", "b"]);
   expect(splitQueries("   a ;  b ")).toEqual(["a", "b"]);
-  expect(splitQueries('"a;b";c')).toEqual(["a;b", "c"]);
+  expect(splitQueries(`"a"`)).toEqual([`"a"`]);
+  expect(splitQueries(`"a;b";c`)).toEqual([`"a;b"`, "c"]);
   expect(splitQueries("a; ;c")).toEqual(["a", "c"]);
 });
 


### PR DESCRIPTION
This made it impossible to use any search queries with quotes in it.

Closes #107