### PR TITLE
fix: stars with TanStack query

### DIFF
--- a/apps/webapp/src/components/PullRow.tsx
+++ b/apps/webapp/src/components/PullRow.tsx
@@ -7,6 +7,7 @@ import styles from "./PullRow.module.scss";
 import { useState } from "react";
 import CopyToClipboardIcon from "./CopyToClipboardIcon";
 import { toggleStar } from "../lib/mutations";
+import { useStars } from "../lib/queries";
 
 export type Props = {
   pull: Pull;
@@ -24,6 +25,7 @@ const formatDate = (d: string) => {
 
 export default function PullRow({ pull }: Props) {
   const [active, setActive] = useState(false);
+  const stars = useStars();
   const handleClick = (e: React.MouseEvent) => {
     // Manually reproduce the behaviour of CTRL+click or middle mouse button.
     if (e.metaKey || e.ctrlKey || e.button == 1) {
@@ -44,7 +46,7 @@ export default function PullRow({ pull }: Props) {
       className={styles.row}
     >
       <td onClick={(e) => handleStar(e)}>
-        {pull.starred ? (
+        {stars.has(pull.uid) ? (
           <IconWithTooltip
             icon="star"
             color="#FBD065"

--- a/apps/webapp/src/lib/mutations.ts
+++ b/apps/webapp/src/lib/mutations.ts
@@ -74,9 +74,12 @@ export async function resetSections(): Promise<void> {
 }
 
 export const toggleStar = async (pull: Pull) => {
-  if (pull.starred) {
-    await db.stars.delete(pull.uid).catch(console.error);
-  } else {
-    await db.stars.add({ uid: pull.uid });
-  }
+  await db.transaction("rw", db.stars, async () => {
+    const star = await db.stars.get(pull.uid);
+    if (star) {
+      await db.stars.delete(pull.uid);
+    } else {
+      await db.stars.add({ uid: pull.uid });
+    }
+  });
 };

--- a/apps/webapp/src/lib/queries.ts
+++ b/apps/webapp/src/lib/queries.ts
@@ -49,6 +49,11 @@ export const useSections = () => {
   };
 };
 
+export const useStars = () => {
+  const data = useLiveQuery(() => db.stars.toArray());
+  return new Set(data?.map((v) => v.uid) || []);
+};
+
 export const usePulls = ({
   connections,
   sections,

--- a/apps/webapp/src/routes/stars.tsx
+++ b/apps/webapp/src/routes/stars.tsx
@@ -1,5 +1,10 @@
 import { Card, Spinner } from "@blueprintjs/core";
-import { useConnections, usePulls, useSections } from "../lib/queries";
+import {
+  useConnections,
+  usePulls,
+  useSections,
+  useStars,
+} from "../lib/queries";
 import Navbar from "../components/Navbar";
 import PullTable from "../components/PullTable";
 import { useState } from "react";
@@ -14,6 +19,7 @@ export default function Stars() {
     connections: connections.data,
     sections: sections.data,
   });
+  const stars = useStars();
   useTitle(pulls.data ?? []);
   return (
     <>
@@ -30,7 +36,7 @@ export default function Stars() {
         ) : (
           <PullTable
             pulls={pulls.data.filter(
-              (pull) => pull.starred && pullMatches(search, pull),
+              (pull) => stars.has(pull.uid) && pullMatches(search, pull),
             )}
           />
         )}

--- a/apps/webapp/tests/testing.ts
+++ b/apps/webapp/tests/testing.ts
@@ -36,7 +36,6 @@ export function mockPull(props?: Omit<Partial<Pull>, "uid" | "url">): Pull {
     labels: [],
     uid: `${connection}:${id}`,
     host,
-    starred: false,
     sections: [],
     connection,
     ...props,

--- a/packages/github/src/types.ts
+++ b/packages/github/src/types.ts
@@ -88,7 +88,6 @@ export type Attention = {
 export type Pull = PullProps & {
   uid: string;
   host: string;
-  starred: boolean;
   sections: string[];
   attention?: Attention;
   connection: string;

--- a/packages/github/tests/attention.test.ts
+++ b/packages/github/tests/attention.test.ts
@@ -243,7 +243,6 @@ function mockPull(props?: Omit<Partial<Pull>, "uid" | "url">): Pull {
     labels: [],
     uid: `1:1`,
     host: "github.com",
-    starred: false,
     sections: [],
     connection: "1",
     ...props,


### PR DESCRIPTION
The 'starred' attribute is now computed only when pulls are fetched, now that we are using TanStack query. It means that (un)starring a pull request was basically broken since the move to TanStack query. This change remove the 'starred' attribute from the Pull type, and determines on-the-fly whether a pull request is starred.