### PR TITLE
refactor: make a useToaster hook

### DIFF
--- a/apps/webapp/src/components/ConnectionDialog.tsx
+++ b/apps/webapp/src/components/ConnectionDialog.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 import { isTruthy } from "remeda";
 import ConfirmDialog from "./ConfirmDialog";
 import type { ConnectionProps } from "../lib/types";
-import { AppToaster } from "../lib/toaster";
+import { useToaster } from "../lib/toaster";
 import OrgSelector from "./OrgSelector";
 
 type Props = {
@@ -50,6 +50,7 @@ export default function ConnectionDialog({
   const [orgs, setOrgs] = useState<string[]>([]);
   const [isDeleting, setDeleting] = useState(false);
   const [isDisabled, setDisabled] = useState(false);
+  const toaster = useToaster();
 
   const handleOpening = () => {
     setDisabled(false);
@@ -69,7 +70,7 @@ export default function ConnectionDialog({
         onClose && onClose();
       } catch (e) {
         const message = `Something went wrong: ${(e as Error).message}`;
-        (await AppToaster).show({ message, intent: Intent.DANGER });
+        toaster?.show({ message, intent: Intent.DANGER });
       }
     }
   };

--- a/apps/webapp/src/components/SectionDialog.tsx
+++ b/apps/webapp/src/components/SectionDialog.tsx
@@ -11,7 +11,7 @@ import {
   TextArea,
 } from "@blueprintjs/core";
 import { useState } from "react";
-import { AppToaster } from "../lib/toaster";
+import { useToaster } from "../lib/toaster";
 import ConfirmDialog from "./ConfirmDialog";
 import {
   DEFAULT_SECTION_LIMIT,
@@ -46,6 +46,7 @@ export default function SectionDialog({
 }: SectionDialogProps) {
   const [data, setData] = useState<SectionProps>(emptySection);
   const [isDeleting, setDeleting] = useState(false);
+  const toaster = useToaster();
 
   const handleOpening = () => {
     if (section) {
@@ -74,7 +75,7 @@ export default function SectionDialog({
     await navigator.clipboard.writeText(
       `${window.location.origin}/inbox?${params.toString()}`,
     );
-    (await AppToaster).show({
+    toaster?.show({
       message: "Share URL has been copied to clipboard.",
       intent: Intent.SUCCESS,
     });

--- a/apps/webapp/src/lib/toaster.ts
+++ b/apps/webapp/src/lib/toaster.ts
@@ -1,10 +1,26 @@
-import { OverlayToaster } from "@blueprintjs/core";
+import { OverlayToaster, type Toaster } from "@blueprintjs/core";
 import { createRoot } from "react-dom/client";
+import { useIsClient } from "usehooks-ts";
+import { useEffect } from "react";
 
-export const AppToaster = OverlayToaster.createAsync(
-  {},
-  {
-    domRenderer: (toaster, containerElement) =>
-      createRoot(containerElement).render(toaster),
-  },
-);
+let toaster: Toaster | undefined;
+
+export function useToaster() {
+  const isClient = useIsClient();
+
+  useEffect(() => {
+    if (isClient && !toaster) {
+      OverlayToaster.createAsync(
+        {},
+        {
+          domRenderer: (toaster, containerElement) =>
+            createRoot(containerElement).render(toaster),
+        },
+      )
+        .then((v) => (toaster = v))
+        .catch(console.error);
+    }
+  }, [isClient]);
+
+  return toaster;
+}

--- a/apps/webapp/src/routes/settings.tsx
+++ b/apps/webapp/src/routes/settings.tsx
@@ -12,7 +12,7 @@ import {
 } from "../lib/mutations";
 import type { Connection, ConnectionProps } from "../lib/types";
 import styles from "./settings.module.scss";
-import { AppToaster } from "../lib/toaster";
+import { useToaster } from "../lib/toaster";
 import { useNavigate } from "react-router";
 import { gitHubClient } from "../github";
 
@@ -22,6 +22,7 @@ export default function Settings() {
   const connections = useConnections();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const toaster = useToaster();
 
   const allowedUrls = import.meta.env.MERGEABLE_GITHUB_URLS
     ? import.meta.env.MERGEABLE_GITHUB_URLS.split(",")
@@ -43,7 +44,7 @@ export default function Settings() {
   };
   const handleReset = async () => {
     await resetSections();
-    (await AppToaster).show({
+    toaster?.show({
       message: "Configuration has been reset to factory settings",
       intent: "success",
     });

--- a/apps/webapp/src/worker.ts
+++ b/apps/webapp/src/worker.ts
@@ -5,7 +5,11 @@ import { db } from "./lib/db";
 const sendTelemetryIntervalMillis = 24 * 60 * 60_000; // 1 day
 
 // Domains that we do not need to hash.
-const domainsWhitelist = new Set(["localhost", "mergeable.pages.dev", "app.usemergeable.dev"]);
+const domainsWhitelist = new Set([
+  "localhost",
+  "mergeable.pages.dev",
+  "app.usemergeable.dev",
+]);
 
 // Schema version is used to force bursting the local cache of pull requests
 // when there is a change that requires it (e.g., adding a new field that must

--- a/apps/webapp/tests/components/ConnectionDialog.test.tsx
+++ b/apps/webapp/tests/components/ConnectionDialog.test.tsx
@@ -1,8 +1,8 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, renderHook, waitFor } from "@testing-library/react";
 import { userEvent, type UserEvent } from "@testing-library/user-event";
 import ConnectionDialog from "../../src/components/ConnectionDialog";
-import { AppToaster } from "../../src/lib/toaster";
+import { useToaster } from "../../src/lib/toaster";
 import type { ConnectionProps } from "../../src/lib/types";
 import { mockConnection } from "../testing";
 
@@ -142,7 +142,9 @@ describe("ConnectionDialog", () => {
     await clickButton("Submit");
 
     // THEN it should display a toast.
-    expect((await AppToaster).getToasts()).toHaveLength(1);
+    const { result } = renderHook(useToaster);
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current?.getToasts()).toHaveLength(1);
 
     // THEN it should not close the dialog.
     expect(state.closed).toBe(false);


### PR DESCRIPTION
The previous method was not easy to use (because of the required `await`) and not compatible with server-side rendering.