### PR TITLE
build: target ES6

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query-persist-client": "^5.75.4",
     "@types/uuid": "^10.0.0",
     "clsx": "^2.1.1",
+    "core-js": "3.42.0",
     "dexie": "^4.0.9",
     "dexie-react-hooks": "^1.1.7",
     "graphql": "^16.11.0",

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -11,7 +11,7 @@ import { createQueryClient, createIDBPersister } from "./lib/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BlueprintProvider } from "@blueprintjs/core";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import "core-js/actual/array"; // Polyfill
+import "core-js/actual/array"; // Polyfill for ES2023.Array
 import type { Route } from "./+types/root";
 import "normalize.css/normalize.css";
 import "@blueprintjs/core/lib/css/blueprint.css";

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -11,6 +11,7 @@ import { createQueryClient, createIDBPersister } from "./lib/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BlueprintProvider } from "@blueprintjs/core";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import "core-js/actual/array"; // Polyfill
 import type { Route } from "./+types/root";
 import "normalize.css/normalize.css";
 import "@blueprintjs/core/lib/css/blueprint.css";

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -13,7 +13,7 @@
     "composite": true,
     "types": ["node"],
     "target": "esnext",
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "bundler",
     "noEmit": true,
   }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -14,7 +14,6 @@
     "types": ["node"],
     "target": "esnext",
     "module": "nodenext",
-    "moduleResolution": "bundler",
     "noEmit": true,
   }
 }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -11,7 +11,6 @@
   ],
   "compilerOptions": {
     "composite": true,
-    "types": ["node"],
     "target": "esnext",
     "module": "nodenext",
     "noEmit": true,

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -12,7 +12,7 @@
   "compilerOptions": {
     "composite": true,
     "types": ["node"],
-    "target": "es2015",
+    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -12,8 +12,8 @@
   "compilerOptions": {
     "composite": true,
     "types": ["node"],
-    "target": "ES2022",
-    "module": "ES2022",
+    "target": "es2015",
+    "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
   }

--- a/apps/web/tsconfig.vite.json
+++ b/apps/web/tsconfig.vite.json
@@ -15,7 +15,7 @@
     "types": ["@testing-library/jest-dom", "vite/client"],
     "rootDirs": [".", "./.react-router/types"],
     "target": "es2015",
-    "lib": ["es2023", "DOM", "WebWorker"],
+    "lib": ["ES2015", "ES2023.Array", "DOM", "WebWorker"],
     "useDefineForClassFields": true,
     "module": "ESNext",
     "sourceMap": true,

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -2,8 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "lib": ["es2023"],
-    "target": "es2015",
     "composite": false,
     "declaration": true,
     "declarationMap": true,
@@ -11,7 +9,6 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
-    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/packages/vite-plugin-process-env/tsconfig.json
+++ b/packages/vite-plugin-process-env/tsconfig.json
@@ -3,4 +3,8 @@
   "extends": "@repo/typescript-config/base.json",
   "include": ["src", "tests"],
   "exclude": ["node_modules"],
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      core-js:
+        specifier: 3.42.0
+        version: 3.42.0
       dexie:
         specifier: ^4.0.9
         version: 4.0.9
@@ -3649,6 +3652,9 @@ packages:
 
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
+
+  core-js@3.42.0:
+    resolution: {integrity: sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -11470,6 +11476,8 @@ snapshots:
   copy-anything@2.0.6:
     dependencies:
       is-what: 3.14.1
+
+  core-js@3.42.0: {}
 
   cors@2.8.5:
     dependencies:


### PR DESCRIPTION
Support all browsers starting at ES6/ES2015. Include polyfills for older browsers. Closes #78.